### PR TITLE
Add some common github workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    # Run every Tuesday at 7am
+    - cron: '0 7 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'typescript']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/typedoc-PR.yml
+++ b/.github/workflows/typedoc-PR.yml
@@ -1,0 +1,38 @@
+name: Typedoc Doc PR Action
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Build Docs w/Typedoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: c-hive/gha-yarn-cache@v2
+
+      - name: Install Yarn Dependencies
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: "install --ignore-engines --ignore-scripts"
+
+      - name: Build Docs
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: docs
+
+      - run: sudo chown -R $USER:$USER .
+
+      - name: Create PR (if required)
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GNARBOT_TOKEN }}
+          add-paths: 'docs/*'
+          commit-message: '📄 Updating Docs 📄'
+          delete-branch: true
+          labels: |
+            docs
+            automated
+          title: 'Updating Docs 📄'
+          body: |
+            Updating Docs from recent Merge

--- a/.github/workflows/yarn-lint.yml
+++ b/.github/workflows/yarn-lint.yml
@@ -1,0 +1,25 @@
+name: Lint (Yarn)
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    name: Lint (Yarn)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: c-hive/gha-yarn-cache@v2
+
+      - name: Install Yarn Dependencies
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: "install --ignore-engines --ignore-scripts"
+
+      - name: Run Linters
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: lint

--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -1,0 +1,29 @@
+name: Run Tests (Yarn)
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    name: Run Tests (Yarn)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: c-hive/gha-yarn-cache@v2
+
+      - name: Install Yarn Dependencies
+        run: "yarn install --ignore-engines --ignore-scripts"
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+
+      - name: Run Tests
+        run: yarn test
+
+      - name: Code Cov
+        uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
I noticed that github orgs can share workflows between them. Though I originally intended this to be the start of a `gnar-cli` script, I now wonder if we can just share these scripts from this repo directly. Investigating further. 