### PR TITLE
Bump Rspec version, remove rspec-its

### DIFF
--- a/rails/7/gnarly.rb
+++ b/rails/7/gnarly.rb
@@ -58,8 +58,7 @@ def add_gems
     gem "pronto-rubocop", require: false
     gem "pry-byebug"
     gem "pry-rails"
-    gem "rspec-its"
-    gem "rspec-rails", "~> 4"
+    gem "rspec-rails", "~> 5"
     gem "rubocop-rspec", require: false
     gem "shoulda-matchers"
     gem "simplecov", require: false


### PR DESCRIPTION
As noted [by ethan](https://github.com/TheGnarCo/job-board/pull/220#discussion_r866839692), the Gnarrc opinions on rspec are a little behind. this updates them! 